### PR TITLE
Glossary edits and READMED

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# VIEWS FOA_Index
+# VIEWS FAO_Index
 
 ![Project Banner](https://pbs.twimg.com/profile_banners/1237000633896652800/1717069203/1500x500)
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,28 +1,29 @@
 # Glossary of Terms and Concepts
-*In progress for second round of review and edits*
 
 ## 1. **Event**
-**Definition:** A single observation of non-zero values within a well-defined temporospatial unit. The exact definition of an event is influenced by the specific spatial and temporal aggregation used for a given analysis. This may include aggregations at various levels such as a 1x1 PRIO grid cell month, a 2x2 PRIO grid cell year, an administrative unit month, a country year, or other defined units. The non-zero value could represent one of several different measures of fatalities contained in the data (see codebook for details). While various measures exist, the primary feature used is the total conflict-related fatalities per 100k population, with the base level of analysis being the monthly PRIO grid cell.
+**Definition:** A single observation of non-zero values within a well-defined temporospatial unit. The exact definition of an event is influenced by the specific spatial and temporal aggregation used for a given analysis. This may include aggregations at various levels such as a 1x1 PRIO-GRID cell month, a 3x3 PRIO-GRID cell year, an administrative unit month, a country year, or any other applicable and defined units. The primary feature measured for an event is total conflict-related fatalities and total conflict-related fatalities per 100 000 people. The measure of conflict-related fatalities is defined by the Uppsala Conflict Data Program (UCDP), capturing all state-based, non-state and one-sided conflict. A non-zero value may represent one of a few varying measures of fatalities -- depending on the data used (see codebook for details) -- since total fatalities may be disaggregated into state-based, non-state, and one-sided conflict. The base level of analysis is a monthly 1x1 PRIO-GRID cell, which can be aggregated to other temporospatial units.
 
-**Example:** An event could be the number of fatalities per 100k population recorded in a grid cell during a specific month. An event could be the number of conflict-related fatalities per 100k population recorded in a specific grid cell during a particular month.
+**Example:** An event is the total number of conflict-related fatalities recorded in a specific grid cell in a specific month. This may be aggregated to the total number of conflict-related fatalities per 100 000 in all grid cells within an administrative unit in a particular year. It would include all non-zero values of fatalities related to conflict issues exceeding 25 battle-related deaths in a given calendar year. 
 
-## 2. **(PRIO) Grid Cell**
-**Definition:** The smallest spatial unit in the analysis, defined by specific geographic coordinates and time intervals. It is the basic unit used to measure events (e.g., fatalities per 100k population).
-**Example:** A PRIO grid cell is a $0.5 \times 0.5$ decimal degrees geographic area observed over a month.
+## 2. **PRIO-GRID Cell**
+**Definition:** The smallest spatial unit, defined by specific geographic coordinates and time intervals. It is the basic unit used to measure events (e.g., fatalities per 100k population). One PRIO-GRID cell is $0.5 \times 0.5$ decimal degrees or approximately 55 \times 55 kilometers at the Equator with cell area decreasing at higher latitudes because of the earth's curvature. This may be referred to simply as a *grid cell* with the spatial aggregation specified such as 1 \times 1, referring to a single PRIO-GRID cell, or 3 \times 3, referring to an aggregation of three neighbouring PRIO-GRID cells. A PRIO-GRID cell may be presented at either a monthly or yearly temporal unit. 
+
+**Example:** One *grid cell* of a $0.5 \times 0.5$ decimal degrees geographic area observed over a month.
 
 ## 3. **Time Period**
-**Definition:** The temporal component associated with a grid cell. This could represent a month, year, or any other defined period during which data is recorded or analyzed.
-**Example:** If the time period unit is months, December 2023 is an example of a time period, which would measure monthly fatalities per 100k population. If the time period unit is years, then 2023 is an example of a time period, which would measure annual fatalities per 100k population.
+**Definition:** The temporal component associated with a grid cell. The smallest temporal unit is one month and may be aggregated to larger units. Therefore, a time period may represent a month, year, or any other defined period consisting of aggregated monthly units over which data is recorded or analyzed.
+
+**Example:** December 2023 is a *monthly* time period, while 2023 is a *yearly* time period. Each time period example would measure the non-zero count of total fatalities or total fatalities per 100 000 people for a specific geographic unit. Thus, December 2023 could measure the count of total fatalities in a single grid cell. A time period of 2023 would aggregate all observations across every month within the calendar year. It would be all non-zero events from January 2023 through December 2023. 
 
 ## 4. **Potential Event**
-**Definition:** Any temporospatial unit within the defined geographic and temporal scope that could potentially contain an event. The exact definition of a potential event is influenced by the specific spatial and temporal aggregation used in the analysis. This may include aggregations at various levels such as a 1x1 PRIO grid cell month, a 2x2 PRIO grid cell year, an administrative unit month, a country year, or other defined unit
+**Definition:** Any temporospatial unit within the defined geographic and temporal scope that could potentially contain an event. The exact definition of a potential event is influenced by the specific spatial and temporal aggregation used in the analysis. This may include aggregations at various levels such as a 1 \times 1 PRIO-GRID cell month, a 3 \times 3 PRIO grid cell year, an administrative unit month, a country year, or other defined unit.
 
-**Example:** If a country is divided into 100 grid cells and observed over 400 months, there are 40,000 potential events. Naturally, this number is very dependent on the spatial and temporal scale defined for the analysis.
+**Example:** If a country is divided into 100 grid cells and observed over 400 months, there are 40,000 potential events. Naturally, this number is dependent on the defined spatial and temporal scale.
 
 ## 5. **Cumulative Distribution Function (CDF)**
-**Definition:** A function that represents the cumulative probability of observing a value of a certain magnitude or lower. In this context, it shows the probability of seeing a certain number of fatalities per 100k population or fewer in any grid cell.
+**Definition:** A function that represents the cumulative probability of observing a value of a certain magnitude or lower. In this context, it shows the probability of seeing a certain number of fatalities (total or per 100 000 people) or fewer in any given grid cell.
 
-**Example:** A CDF value of 0.7 at 10 fatalities per 100k means there's a 70% chance of observing 10 or fewer fatalities per 100k in a random grid cell.
+**Example:** A CDF value of 0.7 at 10 fatalities per 100k means there's a 70% chance of observing 10 or fewer fatalities per 100 000 people in a random grid cell.
 
 ## 6. **Event Probability (p_i)**
 **Definition:** The probability of observing an event of a specific magnitude or larger in a single grid cell, derived from the CDF. It is essentially the complement of the CDF at a given value, representing the probability of exceeding that value.
@@ -30,32 +31,34 @@
 **Formula:** 
 $$p_i = 1 - \text{CDF}(\text{value})$$
 
-Where $p_i$ represents the probability of observing an event with more than a specified number of fatalities per 100k population.
+Where $p_i$ represents the probability of observing an event with more than a specified number of fatalities per 100 000 people.
 
-**Example:**  If the CDF at 10 fatalities per 100k is 0.7, then $p_i$ is 0.3, meaning there's a 30% chance of observing more than 10 fatalities per 100k in a random grid cell.
+**Example:**  If the CDF at 10 fatalities per 100 000 is 0.7, then $p_i$ is 0.3, meaning there's a 30% chance of observing more than 10 fatalities per 100 000 people in a random grid cell.
 
 ## 7. **Event Return Period (e_i)**
-**Definition:** The expected number of potential events (e.g. monthly grid cells) that need to be observed to detect at least one event of a specific magnitude or larger. In probability theory, this concept is akin to "trials," which refer to independent experiments or observations with binary outcomes—success or failure. In our context, a "trial" corresponds to observing a single potential event (e.g. monthly grid cell) within a defined temporal and spatial scope to determine whether an event of a specified magnitude or larger occurs. Given this perspective, each "trial" is conducted within a "potential event" space, where, for instance, each monthly grid cell represents a potential event. In mathematical terms, a "trail" would then be a "success" if the observed value in that grid cell was equal to or above a predefined feature value. If $p_i$ is the probability of such an event, then:
+**Definition:** The expected number of potential events (e.g. monthly grid cells) that need to be observed to detect at least one event of a specific magnitude or larger. In probability theory, this concept is akin to "trials," which refer to independent experiments or observations with binary outcomes of success or failure. In our context, a "trial" corresponds to observing a single potential event within a defined temporal and spatial scope (e.g. monthly grid cell) to determine whether an event of a specified magnitude or larger occurs. Given this perspective, each "trial" is conducted within a "potential event" space with each defined temporospatial grid cell representing a potential event. In mathematical terms, a "trial" would then be a "success" if the observed value in that grid cell was equal to or above a predefined feature value. If $p_i$ is the probability of such an event, then:
 
 **Formula:** 
 
 $$e_i = \frac{1}{p_i}$$ 
 
-Where $e_i$ represents the expected number of trials (i.e. potential events, e.g. monthly grid cells observed) needed to see at least one event of the specified size or larger. This inverse relationship reflects that as the probability of the event ($p_i$) decreases, the expected number of observations needed increases.
+Where $e_i$ represents the expected number of trials (i.e. potential events, e.g. monthly grid cells observed) needed in order to observe at least one event of the specified size or larger. This inverse relationship reflects that as the probability of the event ($p_i$) decreases, the expected number of observations needed increases.
 
-**Example:** If $p_i$ is 0.1, the event return period $e_i$ is 10, meaning that, on average, you would need to observe 10 potential events (e.g., monthly grid cells) to see at least one event of that size or larger. It is important to note that despite the use of the term "period" here, these observations do not have to be distributed across time. For example, using monthly grid cells: If a small country consists of only ten grid cells, these would all be potential events within a single month. An event return period of 10 would mean that we expect to see such an event, on average, every month since each month provides ten potential events.
+**Example:** If $p_i$ is 0.1 and the event return period $e_i$ is 10, then, on average 10 potential events (e.g., non-zero values in monthly grid cells) must be observed to capture at least one event of the specified size or larger. 
+
+It is important to note that despite the use of the term "period" here, these observations do not have to be distributed across time. Using monthly 1 \times 1 grid cells as an example: if there is a small defined country of only 10 1 \times 1 grid cells, then there are 10 potential events within a single month. Subsequently, if a return period is defined as 10, then only 10 "trials" are needed in order to observe an event and, therefore, within a country of only 10 grid cells at an event (observation of non-zero values) would be observed on average every month since there are only 10 potential events. 
 
 
 ## 8. **At Least One Occurrence Probability (P_i)**
-**Definition:** The probability of observing at least one event of a specific magnitude or larger across multiple spatial units (e.g. grid cells) within a defined time period (e.g. month). Again, we can think of this as "trials" in probability theory, where each trial has a binary outcome - success (event occurs) or failure (no event occurs). Here, each spatial unit (e.g. grid cell) within the spatial area under consideration (such as a country) during a specific time period (e.g., one month) is treated as an independent trial.
+**Definition:** The probability of observing at least one event of a specific magnitude or larger across multiple spatial units (e.g. grid cells) within a defined time period (e.g. month). This is an expansion of $p_i$, incorporating a define temporal scope into the probability of observing at least one occurrence of an event. Taking the probability theory concept of "trials" again, a specific combined spatial unit (e.g. grid cell, 1 \times 1, 3 \times 3, etc.) and temporal unit (e.g. month) within the spatial area under consideration (such as a country) is treated as an independent "trial" with a binary outcome – success (non-zero event occurs) or failure (no non-zero event occurs). 
 
 $P_i$ reflects the likelihood of observing at least one event within the spatial area during a given time period, accounting for the number of potential events (grid cells). This normalization by the number of spatial units (e.g. grid cells) ensures that $P_i$ is independent of the size of the area, focusing solely on the likelihood of event occurrence during that time period.
 
-This is in contrast to $p_i$ where a large country will experience more "rare" events than a small country since it contains more potential events each time period. As such, $P_i$ serves as a time-based measure, representing the likelihood of observing an event in any given period (e.g., month) regardless of the size of the spatial area. If $p_i$ is the event probability and $n^{pg}$ is the total number of PRIO grid cells, we have:
+This is in contrast to $p_i$ where a large country will experience more "rare" events than a small country since it contains more potential events each time period. As such, $P_i$ serves as a time-based measure, representing the likelihood of observing an event in any specified given period (e.g., month), regardless of the size of the spatial area. If $p_i$ is the event probability and $n^{pg}$ is the total number of PRIO grid cells, we have:
 
 **Formula:** $$P_i = 1 - (1 - p_i)^{n^{pg}}$$
 
-Where $P_i$ is the probability of observing at least one event of the specified magnitude across the grid cells (trials), assuming each grid cell acts independently. When num_grid_cells = 1, the probability of observing at least one event $P_i$​ is simply equal to the event probability $p_i$​, as there is only one trial (one grid cell) to consider.
+Where $P_i$ is the probability of observing at least one event of the specified magnitude across the grid cells ("trials"), assuming each grid cell acts independently. When num_grid_cells = 1, the probability of observing at least one event $P_i$​ is simply equal to the event probability $p_i$​, as there is only one trial (one grid cell) to consider.
 
 **Example:** For instance, if $p_i$ is 0.1 and you have 100 grid cells, $P_i$ would be approximately 0.999, indicating a 99.9% chance of observing at least one event of the specified magnitude across those grid cells within a single time period. However, if you only have 1 grid cell, $P_i$ simplifies to $p_i$, meaning there would be a 10% chance of observing the event in that single grid cell.
 
@@ -65,7 +68,7 @@ Where $P_i$ is the probability of observing at least one event of the specified 
 **Formula:** 
 $$E_i = \frac{1}{P_i}$$
 
-**Example (Annual):** If $P_i$ is 0.1 and you have 100 years of observation, $E^a_i$ would be 10 years, meaning the event is expected to occur once every 10 years on average within the specific geographical region (e.g. country).
+**Example (Annual):** If $P_i$ is 0.1 and you have 100 years of observation, $E^a_i$ would be 10 years, meaning the event is expected to occur once every 10 years on average within the specific geographic region (e.g. country).
 
 **Example (Monthly):** If $P_i$ is 0.1 and you have 100 months of observation, $E^m_i$ would be 10 months, meaning the event is expected to occur once every 10 months on average within the specific geographical region (e.g. country).
 
@@ -79,17 +82,17 @@ $$E_i = \frac{1}{P_i}$$
 ## 11. **Exceedance Probability (EP)**
 **Definition:** The probability that the magnitude of a specific event will be exceeded within a given time period. This metric is commonly used in risk management to assess the likelihood of extreme or rare events, helping to inform preparedness and mitigation strategies.
 
-**Example:** For example, an exceedance probability of 0.05 for 100 fatalities per 100k population means there is a 5% chance of exceeding 100 fatalities per 100k population within the specified time period.
+**Example:** For example, an exceedance probability of 0.05 for 100 fatalities per 100 000 people means that there is a 5% chance of exceeding 100 fatalities per 100 000 people within the specified time period.
 
 ## 12. **Parametric Insurance**
 **Definition:** A type of insurance that triggers a payout when predefined conditions or parameters are met, such as when an event of a specific magnitude occurs. This differs from traditional insurance, which compensates for actual losses incurred.
 
-**Example:** For example, a parametric insurance policy might pay out if the number of fatalities per 100k population exceeds a predefined threshold within a given month.
+**Example:** For example, a parametric insurance policy might pay out if the number of fatalities per 100 000 people exceeds a predefined threshold within a given month.
 
 ## 13. **Temporal Aggregation**
 **Definition:** The process of combining data over time by summing or averaging to form a single summary for a defined time period. Temporal aggregation is used to create annual, monthly, or other time-based summaries from finer-grained data, providing a broader view of trends.
 
-**Example:** For example, aggregating daily fatalities per 100k population data to produce a monthly total gives a more comprehensive overview of fatalities over that month.
+**Example:** For example, aggregating daily fatalities per 100 000 population data to produce a monthly total gives a more comprehensive overview of fatalities over that month.
 
 ## 14. **Spatial Aggregation**
 **Definition:** The process of combining data from multiple smaller spatial units (e.g., grid cells) to form a larger spatial unit for analysis, such as aggregating grid cells to create a regional or national summary.


### PR DESCRIPTION
1. README: fixed typo (VIEWS_FOA_Index to VIEWS_FAO_Index) – kept in this PR only because the change is so small.

2. glossary.md: Edited the glossary to integrate into the overleaf report. Changes to some language had to occur for it to have the same tone, terminology, etc. Additionally, had to include examples and reference to "total fatalities", not just "total fatalities per 100 000 people" to bring the language in line with the decision to additionally present non-per capita fatalities (as requested by partners). 

Final thought, due to on-going discussions of best terminology for big_e, little_e, big_p, and little_p: If time-based event return period is still not the preferred termed the label of "normalized event return period" (and maybe "normalized event probability") could be considered. This could be considered since the difference in designs draw from the basis of normalizing by the number of given spatial units (P_i = 1 - (1 - p_i)^{n^{pg}}), which is what produces the likelihood of observing a non-zero event in any given period regardless of the size of the spatial area (number of grid cells). 